### PR TITLE
Fix C++11 Meson testing builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,7 @@ branches:
   except:
     - master
     - /^(wip\/)?(travis|osx|mingw|ipp)(\-.+)?$/
+    - cxx11-meson
 
 configuration: Debug
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ before_install:
 #- if [ "${BUILD_SYSTEM}" = "meson" ]; then wget -O /tmp/ninja-linux.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep -oP 'https://github.com/ninja-build/ninja/releases/download/v[0-9\.]+/ninja-linux.zip') && unzip -q /tmp/ninja-linux.zip -d ~/bin && pyenv local 3.6 && pip3 install meson; fi
 
 script:
- - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson . build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
+ - if [ "${BUILD_SYSTEM}" = "meson" ]; then mkdir build && meson . build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
  - if [ "${BUILD_SYSTEM}" = "meson" ]; then ninja -Cbuild test; else make test; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,11 +135,9 @@ matrix:
     ## Meson
     ###
     - env: BUILD_SYSTEM=meson
-      dist: xenial
+      dist: bionic
       addons:
         apt:
-          sources:
-          - ubuntu-toolchain-r-test
           packages:
           - meson
           - ninja-build
@@ -150,7 +148,7 @@ before_install:
 #- if [ "${BUILD_SYSTEM}" = "meson" ]; then wget -O /tmp/ninja-linux.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep -oP 'https://github.com/ninja-build/ninja/releases/download/v[0-9\.]+/ninja-linux.zip') && unzip -q /tmp/ninja-linux.zip -d ~/bin && pyenv local 3.6 && pip3 install meson; fi
 
 script:
- - if [ "${BUILD_SYSTEM}" = "meson" ]; then mkdir build && meson . build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
+ - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
  - if [ "${BUILD_SYSTEM}" = "meson" ]; then ninja -Cbuild test; else make test; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,7 @@ matrix:
           - ubuntu-toolchain-r-test
           packages:
           - meson
-          - ninja
+          - ninja-build
 
 before_install:
 - if [ -n "${CXX_COMPILER}" ]; then export CXX="${CXX_COMPILER}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ before_install:
 #- if [ "${BUILD_SYSTEM}" = "meson" ]; then wget -O /tmp/ninja-linux.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep -oP 'https://github.com/ninja-build/ninja/releases/download/v[0-9\.]+/ninja-linux.zip') && unzip -q /tmp/ninja-linux.zip -d ~/bin && pyenv local 3.6 && pip3 install meson; fi
 
 script:
- - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
+ - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson setup . build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
  - if [ "${BUILD_SYSTEM}" = "meson" ]; then ninja -Cbuild test; else make test; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ before_install:
 #- if [ "${BUILD_SYSTEM}" = "meson" ]; then wget -O /tmp/ninja-linux.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep -oP 'https://github.com/ninja-build/ninja/releases/download/v[0-9\.]+/ninja-linux.zip') && unzip -q /tmp/ninja-linux.zip -d ~/bin && pyenv local 3.6 && pip3 install meson; fi
 
 script:
- - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson setup . build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
+ - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson . build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi
  - if [ "${BUILD_SYSTEM}" = "meson" ]; then ninja -Cbuild test; else make test; fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,7 @@ matrix:
     ## Meson
     ###
     - env: BUILD_SYSTEM=meson
+      dist: xenial
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,11 +135,18 @@ matrix:
     ## Meson
     ###
     - env: BUILD_SYSTEM=meson
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - meson
+          - ninja
 
 before_install:
 - if [ -n "${CXX_COMPILER}" ]; then export CXX="${CXX_COMPILER}"; fi
 - if [ "${CXX_COMPILER}" = "pgc++" ]; then wget -q -O /dev/stdout 'https://raw.githubusercontent.com/nemequ/pgi-travis/master/install-pgi.sh' | /bin/sh; fi
-- if [ "${BUILD_SYSTEM}" = "meson" ]; then wget -O /tmp/ninja-linux.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep -oP 'https://github.com/ninja-build/ninja/releases/download/v[0-9\.]+/ninja-linux.zip') && unzip -q /tmp/ninja-linux.zip -d ~/bin && pyenv local 3.6 && pip3 install meson; fi
+#- if [ "${BUILD_SYSTEM}" = "meson" ]; then wget -O /tmp/ninja-linux.zip $(curl -s https://api.github.com/repos/ninja-build/ninja/releases/latest | grep -oP 'https://github.com/ninja-build/ninja/releases/download/v[0-9\.]+/ninja-linux.zip') && unzip -q /tmp/ninja-linux.zip -d ~/bin && pyenv local 3.6 && pip3 install meson; fi
 
 script:
  - if [ "${BUILD_SYSTEM}" = "meson" ]; then meson build && ninja -Cbuild; else make CXX="${CXX}" AGGRESSIVE_WARNINGS=y EXTENSION="${EXTENSION}" OPENMP="${OPENMP}" ASAN="${ASAN}" UBSAN="${UBSAN}"; fi


### PR DESCRIPTION
This commit adds fixes to the CI system for `meson`, including:
- preferring Ubuntu packages over dynamic fetches, and
- using Ubuntu "bionic" instead of "trusty" for `meson` testing.